### PR TITLE
URI encode keys to avoid weird encoding when uploaded

### DIFF
--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -62,7 +62,9 @@ defmodule Arc.Storage.GCS do
   end
 
   defp do_put(path, body, gcs_options, file_name) do
-    url = build_url(path)
+    url = path
+          |> build_url
+          |> URI.encode
     headers = gcs_options ++ default_headers()
 
     case HTTPoison.put!(url, body, headers) do


### PR DESCRIPTION
I was getting strange encoding in my bucket when keys had spaces in them.

Ex. "Photos/New Orleans 2017" would get created in the bucket as "Photos/New+Orleans+2017".

This seems to fix that. I see some other places that encode, namely signed urls. I'm not using them so I'm not sure if this would end up with double encoding.