### PR TITLE
Make hackney options configurable

### DIFF
--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -60,7 +60,7 @@ defmodule Arc.Storage.GCS do
     url = build_url(path)
     headers = gcs_options ++ default_headers()
 
-    case HTTPoison.put!(url, body, headers) do
+    case HTTPoison.put!(url, body, headers, hackney_opts()) do
       %{status_code: 200} ->
         {:ok, file_name}
       %{body: body} ->
@@ -107,6 +107,10 @@ defmodule Arc.Storage.GCS do
       UndefinedFunctionError ->
         []
     end
+  end
+
+  defp hackney_opts() do
+    Application.get_env(:arc_gcs, :hackney_opts, [])
   end
 
   defp default_headers do


### PR DESCRIPTION
This changes makes hackney options like timeouts for send and receive configurable.

Example usage:
```elixir
config :arc_gcs,
  hackney_opts: [
    timeout: 30_000,
    recv_timeout: 30_000
  ]
```

Fixes: #12 
