### PR TITLE
Enable asset_host to override @endpoint

### DIFF
--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -86,6 +86,14 @@ defmodule Arc.Storage.GCS do
       name -> name
     end
   end
+  
+  defp endpoint do
+    case Application.fetch_env(:arc, :asset_host) do
+      :error -> @endpoint
+      {:ok, {:system, env_var}} when is_binary(env_var) -> System.get_env(env_var)
+      {:ok, endpoint} -> endpoint
+    end
+  end
 
   defp gcs_key(definition, version, file_and_scope) do
     definition
@@ -118,7 +126,7 @@ defmodule Arc.Storage.GCS do
   end
 
   defp build_url(path) do
-    "https://#{@endpoint}/#{bucket()}/#{path}"
+    "https://#{endpoint()}/#{bucket()}/#{path}"
   end
 
   defp ensure_keyword_list(list) when is_list(list), do: list

--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -81,9 +81,10 @@ defmodule Arc.Storage.GCS do
   end
 
   defp bucket do
-    case Application.fetch_env!(:arc, :bucket) do
-      {:system, env_var} when is_binary(env_var) -> System.get_env(env_var)
-      name -> name
+    case Application.fetch_env(:arc, :bucket) do
+      :error -> nil
+      {:ok, {:system, env_var}} when is_binary(env_var) -> System.get_env(env_var)
+      {:ok, name} -> name
     end
   end
   
@@ -126,7 +127,10 @@ defmodule Arc.Storage.GCS do
   end
 
   defp build_url(path) do
-    "https://#{endpoint()}/#{bucket()}/#{path}"
+    case bucket() do
+      nil -> "https://#{endpoint()}/#{path}"
+      value ->  "https://#{endpoint()}/#{bucket()}/#{path}"
+    end
   end
 
   defp ensure_keyword_list(list) when is_list(list), do: list

--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -28,7 +28,13 @@ defmodule Arc.Storage.GCS do
   defp build_signed_url(endpoint) do
     {:ok, client_id} = Goth.Config.get("client_email")
     expiration = System.os_time(:seconds) + 86_400
-    path = "/#{bucket()}/#{endpoint}"
+    
+    path = case bucket() do
+      nil ->     "/#{endpoint}"
+      bucket ->  "/#{bucket}/#{endpoint}"
+    end
+    
+
     base_url = build_url(endpoint)
     signature_string = url_to_sign("GET", "", "", expiration, "", path)
     url_encoded_signature = base64_sign_url(signature_string)

--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -31,10 +31,9 @@ defmodule Arc.Storage.GCS do
     
     path = case bucket() do
       nil ->     "/#{endpoint}"
-      bucket ->  "/#{bucket}/#{endpoint}"
+      value ->  "/#{value}/#{endpoint}"
     end
     
-
     base_url = build_url(endpoint)
     signature_string = url_to_sign("GET", "", "", expiration, "", path)
     url_encoded_signature = base64_sign_url(signature_string)
@@ -135,7 +134,7 @@ defmodule Arc.Storage.GCS do
   defp build_url(path) do
     case bucket() do
       nil -> "https://#{endpoint()}/#{path}"
-      value ->  "https://#{endpoint()}/#{bucket()}/#{path}"
+      value ->  "https://#{endpoint()}/#{value}/#{path}"
     end
   end
 


### PR DESCRIPTION
Hi, I created this since I needed to put a cdn in front of my static assets - but the current plugin has hard coded the path to @endpoint. 

Just like the AWS implementation asset_host can now be specified in order to override @endpoint. @bucket is also optional since @endpoint COULD contain the bucket (Google Cloud Loadbalancers typically point directly at buckets). I'm not sure whether we'd want to handle that differently though. 

Let me know what you think.  