### PR TITLE
Add possibility for expires_in option when signing an url

### DIFF
--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -2,6 +2,7 @@ defmodule Arc.Storage.GCS do
   alias Goth.Token
   import SweetXml
 
+  @default_expiry_time 60 * 5
   @endpoint "storage.googleapis.com"
   @full_control_scope "https://www.googleapis.com/auth/devstorage.full_control"
 
@@ -27,14 +28,16 @@ defmodule Arc.Storage.GCS do
     key = gcs_key(definition, version, file_and_scope)
 
     case Keyword.get(options, :signed, false) do
-      true -> build_signed_url(key)
+      true -> build_signed_url(key, options)
       false -> build_url(key)
     end
   end
 
-  defp build_signed_url(endpoint) do
+  defp build_signed_url(endpoint, options) do
     {:ok, client_id} = Goth.Config.get("client_email")
-    expiration = System.os_time(:seconds) + 86_400
+
+    expiration =
+      System.os_time(:seconds) + Keyword.get(options, :expires_in, @default_expiry_time)
 
     path =
       case bucket() do

--- a/test/storage/gcs_test.exs
+++ b/test/storage/gcs_test.exs
@@ -275,6 +275,13 @@ defmodule ArcTest.Storage.GCS do
 
       Application.put_env(:arc, :bucket, env_bucket())
     end
+
+    test "expires_in for signed url are set in URL", %{name: name} do
+      expiration = System.os_time(:seconds) + 10
+
+      assert DummyDefinition.url({@img_name, name}, signed: true, expires_in: 10)
+             |> String.contains?("Expires=#{expiration}")
+    end
   end
 
   describe "endpoint" do


### PR DESCRIPTION
I copied the default expiry_time setting from arc itself and added `expires_in` option for a signed URL.