### PR TITLE
Fix storage dir system config

### DIFF
--- a/test/storage/gcs_test.exs
+++ b/test/storage/gcs_test.exs
@@ -181,12 +181,26 @@ defmodule ArcTest.Storage.GCS do
   end
 
   @tag timeout: 15000
-  test "public put and get with System env", %{name: name} do
+  test "public put and get with system env bucket configuration", %{name: name} do
     Application.put_env(:arc, :bucket, {:system, "ARC_TEST_BUCKET"})
     assert {:ok, @img_name} == DummyDefinition.store({@img_path, name})
     assert_public(DummyDefinition, {@img_name, name})
     delete_and_assert_not_found(DummyDefinition, {@img_name, name})
     Application.put_env(:arc, :bucket, System.get_env("ARC_TEST_BUCKET"))
+  end
+
+  @tag timeout: 15000
+  test "public put and get with system env storage_dir configuration", %{name: name} do
+    System.put_env("TEST_STORAGE_DIR", "test-storage-dir-env")
+    Application.put_env(:arc, :storage_dir, {:system, "TEST_STORAGE_DIR"})
+
+    assert {:ok, @img_name} == DummyDefinitionWithNoStorageDir.store({@img_path, name})
+    assert_public(DummyDefinitionWithNoStorageDir, {@img_name, name})
+
+    delete_and_assert_not_found(DummyDefinition, {@img_name, name})
+
+    Application.delete_env(:arc, :storage_dir)
+    System.delete_env("TEST_STORAGE_DIR")
   end
 
   @tag timeout: 15000
@@ -287,23 +301,18 @@ defmodule ArcTest.Storage.GCS do
     end
 
     test "config storage_dir with ENV", %{name: name} do
-      System.put_env("TEST_BUCKET", "test-bucket-env")
       System.put_env("TEST_STORAGE_DIR", "test-storage-dir-env")
-      Application.put_env(:arc, :bucket, {:system, "TEST_BUCKET"})
       Application.put_env(:arc, :storage_dir, {:system, "TEST_STORAGE_DIR"})
 
       assert DummyDefinitionWithNoStorageDir.url({@img_name, name}, signed: false) ==
-               "https://storage.googleapis.com/test-bucket-env/test-storage-dir-env/#{name}.png"
+               "https://storage.googleapis.com/#{env_bucket()}/test-storage-dir-env/#{name}.png"
 
       assert DummyDefinitionWithNoStorageDir.url({@img_name, name}, signed: true)
              |> String.starts_with?(
-               "https://storage.googleapis.com/test-bucket-env/test-storage-dir-env/#{name}.png"
+               "https://storage.googleapis.com/#{env_bucket()}/test-storage-dir-env/#{name}.png"
              )
 
-      Application.put_env(:arc, :bucket, env_bucket())
       Application.delete_env(:arc, :storage_dir)
-
-      System.delete_env("TEST_BUCKET")
       System.delete_env("TEST_STORAGE_DIR")
     end
 


### PR DESCRIPTION
Hi, thanx for providing this package.

I had an issue with dynamically configuring `storage_dir` as `{:system, value}`.
This isn't handled like how its handled for the `bucket` option.
I've fixed it in a fork and was wondering if you could review, advice on it or merge it in.

Once again thanx for whipping this up for us.