### PR TITLE
Configurable token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ config :goth,
   json: "/path/to/json" |> Path.expand |> File.read!
 ```
 
+#### Custom Token Generation ####
+
+By default, the credentials provided to Goth will be used to generate tokens.
+If you have multiple sets of credentials in Goth or otherwise need more control
+over token generation, you can define your own module:
+
+```elixir
+defmodule MyCredentials do
+  @behaviour Arc.Storage.GCS.TokenFetcher
+
+  @impl Arc.Storage.GCS.TokenFetcher
+  def get_token(scopes) when is_list(scopes), do: get_token(Enum.join(scopes, " "))
+
+  @impl Arc.Storage.GCS.TokenFetcher
+  def get_token(scope) when is_binary(scope) do
+    {:ok, token} = Goth.Token.for_scope({"my-user@my-gcs-account.com", scope})
+    token.token
+  end
+end
+```
+
+And configure it to use this new module instead of the default token generation:
+
+```elixir
+config :arc,
+  storage: Arc.Storage.GCS,
+  bucket: "gcs-bucket-name",
+  token_fetcher: MyCredentials
+```
 
 ### Tests
 

--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -260,24 +260,8 @@ defmodule Arc.Storage.GCS do
     |> Enum.join()
   end
 
-  defmodule TokenFetcher do
-    @callback get_token(binary | [binary]) :: binary
-  end
-
-  defmodule DefaultGothToken do
-    @behaviour TokenFetcher
-
-    @impl TokenFetcher
-    def get_token(scopes) when is_list(scopes), do: get_token(Enum.join(scopes, " "))
-
-    def get_token(scope) when is_binary(scope) do
-      {:ok, token} = Token.for_scope(scope)
-      token.token
-    end
-  end
-
   defp for_scope(scopes) do
-    token_store = Application.get_env(:arc, :token_fetcher, DefaultGothToken)
+    token_store = Application.get_env(:arc, :token_fetcher, Arc.Storage.GCS.Token.DefaultFetcher)
     token_store.get_token(scopes)
   end
 end

--- a/lib/arc/storage/gcs/token/default_fetcher.ex
+++ b/lib/arc/storage/gcs/token/default_fetcher.ex
@@ -1,0 +1,11 @@
+defmodule Arc.Storage.GCS.Token.DefaultFetcher do
+  @behaviour Arc.Storage.GCS.Token.Fetcher
+
+  @impl Arc.Storage.GCS.Token.Fetcher
+  def get_token(scopes) when is_list(scopes), do: get_token(Enum.join(scopes, " "))
+
+  def get_token(scope) when is_binary(scope) do
+    {:ok, token} = Token.for_scope(scope)
+    token.token
+  end
+end

--- a/lib/arc/storage/gcs/token/fetcher.ex
+++ b/lib/arc/storage/gcs/token/fetcher.ex
@@ -1,0 +1,3 @@
+defmodule Arc.Storage.GCS.Token.Fetcher do
+  @callback get_token(binary | [binary]) :: binary
+end


### PR DESCRIPTION
I have multiple sets of credentials in Goth, which means I have to call `for_scope` in a different way. I thought it would be good to allow people full control over the token generation when needed, so I set up a new configuration option that lets you define your own behavior in a module. This also defines a behaviour that the token module should implement.