### PR TITLE
Fixed missing alias for Goth.Token module

### DIFF
--- a/lib/arc/storage/gcs.ex
+++ b/lib/arc/storage/gcs.ex
@@ -1,5 +1,4 @@
 defmodule Arc.Storage.GCS do
-  alias Goth.Token
   alias GoogleApi.Storage.V1.{Api.Objects, Connection, Model.Object}
   alias GoogleApi.Gax.{Request, Response}
 

--- a/lib/arc/storage/gcs/token/default_fetcher.ex
+++ b/lib/arc/storage/gcs/token/default_fetcher.ex
@@ -1,6 +1,8 @@
 defmodule Arc.Storage.GCS.Token.DefaultFetcher do
   @behaviour Arc.Storage.GCS.Token.Fetcher
 
+  alias Goth.Token
+
   @impl Arc.Storage.GCS.Token.Fetcher
   def get_token(scopes) when is_list(scopes), do: get_token(Enum.join(scopes, " "))
 


### PR DESCRIPTION
Fixes a module crash without this alias present.