### PR TITLE
DefaultFetcher - return empty string from for_scope error

### DIFF
--- a/lib/arc/storage/gcs/token/default_fetcher.ex
+++ b/lib/arc/storage/gcs/token/default_fetcher.ex
@@ -4,10 +4,16 @@ defmodule Arc.Storage.GCS.Token.DefaultFetcher do
   alias Goth.Token
 
   @impl Arc.Storage.GCS.Token.Fetcher
-  def get_token(scopes) when is_list(scopes), do: get_token(Enum.join(scopes, " "))
+  def get_token(scopes) when is_list(scopes) do
+    scopes
+    |> Enum.join(" ")
+    |> get_token()
+  end
 
   def get_token(scope) when is_binary(scope) do
-    {:ok, token} = Token.for_scope(scope)
-    token.token
+    case Token.for_scope(scope) do
+      {:ok, token} -> token.token
+      {:error, _} -> ""
+    end
   end
 end

--- a/lib/arc/storage/gcs/token/default_fetcher.ex
+++ b/lib/arc/storage/gcs/token/default_fetcher.ex
@@ -13,7 +13,7 @@ defmodule Arc.Storage.GCS.Token.DefaultFetcher do
   def get_token(scope) when is_binary(scope) do
     case Token.for_scope(scope) do
       {:ok, token} -> token.token
-      {:error, _} -> ""
+      _ -> ""
     end
   end
 end


### PR DESCRIPTION
Curious what you think about this small change, which would resolve #138...

While using this app, my team ran into a situation where the call to `Token.for_scope/1` in `DefaultFetcher.get_token/1` returned an error tuple, which caused a critical failure in our application - `for_scope` was returning `{:error, %HTTPoison.Error{id: nil, reason: :nxdomain}}`, which was causing a "no matching right hand side value" error. You can see why -

```
  def get_token(scope) when is_binary(scope) do
    {:ok, token} = Token.for_scope(scope)
    token.token
  end
```

I wondered a bit about what the correct solution might be, and after following the chain of events, it seemed to me that perhaps just an empty string was the best thing to return in case of an error. Here's how it works -

In `Arc.Storage.GCS`, the private method `conn/0` returns a call to `GoogleApi.Storage.V1.Connection.new/1` - as a callback, that function is provided with `for_scope/1`, which itself returns `get_token/1` - `get_token/1` serves as the "token_fetcher", which is ultimately used in `GoogleApi.Gax.Connection` like so:

```
@spec new(String.t()) :: Tesla.Client.t()
def new(token) when is_binary(token) do
  Tesla.client([
    {Tesla.Middleware.Headers, [{"authorization", "Bearer #{token}"}]}
  ])
end

def new(token_fetcher) when is_function(token_fetcher) do
  token_fetcher.(@scopes)
  |> new
end
```

Surely you already knew all of this, just documenting for posterity...

Since the first definition of `new/1` is expecting a binary, it seems like, in the event of an error in the token fetcher, the best bet would be to simply provide `new/1` with an empty string, and allow the `Tesla.client` request to fail.

Thanks again for all of your hard work on this project - I hope that this is helpful! I'm open to any alternate suggestions you have as well, your consideration is much appreciated.